### PR TITLE
Introduce FixedPoint::into_bits

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,7 +4,7 @@ use core::fmt::{Display, Formatter, Result};
 use derive_more::Error;
 
 #[cfg_attr(feature = "std", derive(Error))]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ArithmeticError {
     Overflow,
     DivisionByZero,
@@ -26,7 +26,7 @@ impl Display for ArithmeticError {
 }
 
 #[cfg_attr(feature = "std", derive(Error))]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FromDecimalError {
     UnsupportedExponent,
     TooBigMantissa,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,10 @@ impl<I, P> FixedPoint<I, P> {
     pub const fn as_bits(&self) -> &I {
         &self.inner
     }
+
+    pub fn into_bits(self) -> I {
+        self.inner
+    }
 }
 
 macro_rules! impl_fixed_point {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,7 @@ impl<I, P> FixedPoint<I, P> {
         &self.inner
     }
 
+    #[inline]
     pub fn into_bits(self) -> I {
         self.inner
     }


### PR DESCRIPTION
We use FixedPoint for calculations, but at the end we want to convert it into u128.
Currently, we have to write:
```
let fp = ...;
(*fp.as_bits()).try_into()
```
or
```
let fp = ...;
fp.as_bits().clone().try_into()
```

I think it's much better to write:
```
let fp = ...;
fp.into_bits().try_into()
```

Also, made `ArithmeticError` and `FromDecimalError` Copy because they are simple and it enables `Result<T, E>: Copy`.