### PR TITLE
allow serde serialization and `TryFrom<f64>` with `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ path = "examples/usage.rs"
 required-features = ["i64"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 typenum = "1.12.0"
 derive_more = { version = "0.99.9", default-features = false }
-parity-scale-codec = { version = "2", default-features = false, optional = true, features = ["derive"] }
+parity-scale-codec = { version = "2", default-features = false, features = ["derive"], optional = true }
 static_assertions = "1.1.0"
 
 [dev-dependencies]

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -1,0 +1,92 @@
+//! Contains logic related to no_std functionaligy
+
+use core::fmt;
+
+/// Avoids the use of [`std::io::Cursor`] in `no_std` context
+pub(crate) struct Cursor<T> {
+    buffer: T,
+    position: usize,
+}
+impl<T> Cursor<T> {
+    pub(crate) fn new(buffer: T) -> Self {
+        Self {
+            buffer,
+            position: 0,
+        }
+    }
+    pub(crate) fn position(&self) -> usize {
+        self.position
+    }
+}
+impl<T: AsMut<[u8]>> fmt::Write for Cursor<T> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let raw_s = s.as_bytes();
+        let pos = self.position();
+
+        let buf = &mut self.buffer.as_mut()[pos..pos + raw_s.len()];
+
+        if raw_s.len() > buf.len() {
+            return Err(fmt::Error);
+        }
+
+        buf.copy_from_slice(raw_s);
+        self.position += raw_s.len();
+
+        Ok(())
+    }
+}
+
+#[cfg(any(test, feature = "std"))]
+fn f64_significant_digits_std(value: f64) -> usize {
+    (value.abs().log10() + 1f64).floor() as usize
+}
+
+#[cfg(any(test, not(feature = "std")))]
+fn f64_significant_digits_no_std(value: f64) -> usize {
+    let mut abs_value = if value.is_sign_negative() {
+        -value
+    } else {
+        value
+    };
+
+    let mut significant = 0;
+    while abs_value >= 1f64 {
+        significant += 1;
+        abs_value /= 10f64;
+    }
+
+    significant
+}
+
+pub(crate) fn f64_significant_digits(value: f64) -> usize {
+    #[cfg(feature = "std")]
+    return f64_significant_digits_std(value);
+
+    #[cfg(not(feature = "std"))]
+    return f64_significant_digits_no_std(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use core::fmt::Write;
+
+    use super::*;
+
+    #[test]
+    fn cursor_over_bytes() {
+        let mut cursor = Cursor::new([0u8; 64]);
+        write!(&mut cursor, "{:.*}", 5, 12.12345f64).unwrap();
+        assert_eq!(cursor.position(), 8);
+    }
+
+    #[test]
+    fn compare_f64_significant_digits_std_and_no_std_output() {
+        let values = [-100., -55.14, -1., -0.5, -0., 0., 0.5, 1., 55.14, 100.];
+
+        for value in values {
+            let no_std_out = f64_significant_digits_no_std(value);
+            let std_out = f64_significant_digits_std(value);
+            assert_eq!(no_std_out, std_out, "mismatch for {}", value);
+        }
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -5,10 +5,9 @@
 //! By default `FixedPoint` is serialized using `as_string` for human readable formats
 //! and `as_repr` for other ones.
 
-use std::{
+use core::{
     convert::TryFrom,
-    fmt::{self, Display},
-    io::{Cursor, Write as _},
+    fmt::{self, Display, Write as _},
     marker::PhantomData,
     str::{self, FromStr},
 };
@@ -18,7 +17,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use crate::{errors::ConvertError, FixedPoint};
+use crate::{errors::ConvertError, no_std::Cursor, FixedPoint};
 
 impl<I, P> Serialize for FixedPoint<I, P>
 where
@@ -96,7 +95,7 @@ pub mod as_string {
         let mut buf = [0; MAX_LEN];
         let mut cursor = Cursor::new(&mut buf[..]);
         let _ = write!(cursor, "{}", fp);
-        let p = cursor.position() as usize;
+        let p = cursor.position();
 
         // The Display instance for numbers produces valid utf-8.
         let s = unsafe { str::from_utf8_unchecked(&buf[..p]) };

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,8 @@
-#[cfg(feature = "std")]
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{format, string::String};
+
 use core::f64;
 use core::i64;
 
@@ -27,7 +31,6 @@ fn from_decimal() -> Result<()> {
 }
 
 #[test]
-#[cfg(feature = "std")]
 fn display() -> Result<()> {
     test_fixed_point! {
         case (x | FixedPoint, expected | &str) => {
@@ -64,7 +67,7 @@ fn from_good_str() -> Result<()> {
             let input: FixedPoint = input.parse()?;
             assert_eq!(input, expected);
 
-            #[cfg(all(feature = "std", feature = "serde"))]
+            #[cfg(feature = "serde")]
             assert_eq!(
                 serde_json::from_str::<FixedPoint>(&format!("\"{}\"", input)).unwrap(),
                 expected
@@ -109,7 +112,7 @@ fn from_bad_str() -> Result<()> {
             let result: Result<FixedPoint, ConvertError> = bad_str.parse();
             assert!(result.is_err(), "must not parse '{}'", bad_str);
 
-            #[cfg(all(feature = "std", feature = "serde"))]
+            #[cfg(feature = "serde")]
             assert!(serde_json::from_str::<FixedPoint>(&format!("\"{}\"", bad_str)).is_err());
         },
         all {
@@ -134,7 +137,7 @@ fn from_bad_str() -> Result<()> {
 }
 
 #[test]
-#[cfg(all(feature = "std", feature = "serde"))]
+#[cfg(feature = "serde")]
 fn serde_with() -> Result<()> {
     test_fixed_point! {
         case (input | f64, expected | FixedPoint) => {
@@ -692,7 +695,6 @@ fn rounding_to_i64() -> Result<()> {
 }
 
 #[test]
-#[cfg(feature = "std")]
 #[allow(clippy::float_cmp)]
 fn to_f64() -> Result<()> {
     test_fixed_point! {
@@ -731,7 +733,6 @@ fn to_f64() -> Result<()> {
 }
 
 #[test]
-#[cfg(feature = "std")]
 #[allow(clippy::float_cmp)]
 fn from_f64() -> Result<()> {
     test_fixed_point! {


### PR DESCRIPTION
* `serde` serialization can now be used with `no_std` (would definitively like to see this merged)
* `TryFrom<f64>` can now be used with `no_std`