### PR TITLE
feat: make FixedPoint repr(transparent)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,7 @@ type Result<T, E = ArithmeticError> = core::result::Result<T, E>;
     docsrs,
     doc(cfg(any(feature = "i128", feature = "i64", feature = "i32", feature = "i16")))
 )]
+#[repr(transparent)]
 pub struct FixedPoint<I, P> {
     inner: I,
     _marker: PhantomData<P>,


### PR DESCRIPTION
This will make the newtype struct behave as an integer which is useful in FFI.
Is there a reason why you wouldn't like to make this API guarantee?